### PR TITLE
Fix translation page meta description

### DIFF
--- a/src/content/docs/guides/i18n.md
+++ b/src/content/docs/guides/i18n.md
@@ -1,6 +1,6 @@
 ---
 title: 🌐 i18n and Translation
-description: How to write and annotate code samples for Astro documentation.
+description: How to help translate the Astro documentation and review translation PRs.
 ---
 
 Thanks for your interest in helping us translate [docs.astro.build](https://docs.astro.build/)! This can be a great way to get involved with open-source development without having to code.


### PR DESCRIPTION
Shared this page and noticed `description` was off.