### PR TITLE
Missing Arabic language from Astro languages

### DIFF
--- a/src/content/docs/guides/i18n.md
+++ b/src/content/docs/guides/i18n.md
@@ -7,6 +7,7 @@ Thanks for your interest in helping us translate [docs.astro.build](https://docs
 
 Currently, we are aiming to translate the Astro documentation into the following languages:
 
+- Arabic
 - Brazilian Portuguese
 - Chinese (Simplified/Traditional)
 - English


### PR DESCRIPTION
Welcome,

I have interest in translating Astro docs to Arabic and also I found it supported in the [list](https://i18n.docs.astro.build/).

![image](https://github.com/withastro/contribute.docs.astro.build/assets/52907282/b5719718-fb6d-4671-9a83-781ab5bdbfd9)
