### PR TITLE
Add new docs for experimental features

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
 					items: [
 						{ label: 'Writing and Style Guide', link: '/guides/writing-style/' },
 						{ label: 'Adding docs for a new feature', link: '/guides/new-feature-docs/' },
+						{ label: 'Adding docs for an experimental flag', link: '/guides/experimental-feature-docs/' },
 						{ label: 'Adding a new Astro + X Guide', link: '/guides/new-third-party-stub/' },
 						{ label: 'Contributing a Recipe', link: '/guides/recipe-writing/' },
 						{ label: 'Translating Astro docs', link: '/guides/i18n/' },	

--- a/src/components/ReadMore.astro
+++ b/src/components/ReadMore.astro
@@ -1,0 +1,24 @@
+---
+import { Icon } from '@astrojs/starlight/components';
+---
+
+<div class="read-more">
+	<Icon class="icon" name="open-book" />
+	<span><slot /></span>
+</div>
+
+<style>
+	.read-more {
+		display: flex;
+		gap: 0.5rem;
+		align-items: flex-start;
+	}
+	.icon {
+		--icon-size: 1.5rem;
+		font-size: var(--icon-size);
+		flex-shrink: 0;
+		/* Align to the middle of the first line of text. */
+		margin-block: calc((var(--sl-line-height) * 1rem - var(--icon-size)) / 2);
+		color: var(--sl-color-text-accent);
+	}
+</style>

--- a/src/content/docs/guides/experimental-feature-docs.md
+++ b/src/content/docs/guides/experimental-feature-docs.md
@@ -1,0 +1,41 @@
+---
+title: Adding docs for experimental features
+description: A guide to writing docs for your feature released behind an experimental flag.
+---
+
+## Unflagging an experimental feature 
+
+Key things:
+
+- noting when this experimental flag was first introduced (there might be some helpful context for someone just now learning about this in case they wants to look up what we said about this when it was first released, either in the changelog or blog post)
+
+- a description of what it is, because it is now essentially a "new feature" of Astro! (I took from the earlier changelog for an example) and some people ignore experimental features. They might have no idea what this is, and it deserves just as much description/fanfare as when it was released as experimental!
+
+- "If you were using this feature..." and code showing removing the experimental flag. (Prompt because this may break projects)
+
+- "If you have been waiting for stabilization before using.... , you can now do so." (Reminding them that maybe they saw this before and thought, "I'll wait!")
+
+- link to finding more info in the docs
+
+Example:
+
+
+The `i18nDomains` routing feature introduced behind a flag in [v3.4.0](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md#430) is no longer experimental and is available for general use.
+
+This routing option allows you to configure different domains for individual locales in entirely server-rendered projects using the [@astrojs/node](https://docs.astro.build/en/guides/integrations-guide/node/) or [@astrojs/vercel](https://docs.astro.build/en/guides/integrations-guide/vercel/) adapter with a `site` configured.
+
+If you were using this feature, please remove the experimental flag from your Astro config:
+
+```diff
+import { defineConfig } from 'astro'
+
+export default defineConfig({
+-  experimental: {
+-    i18nDomains: true,
+-  }
+})
+```
+
+If you have been waiting for stabilization before using this routing option, you can now do so. 
+
+Please see [the internationalization docs](https://docs.astro.build/en/guides/internationalization/#domains) for more about this feature.

--- a/src/content/docs/guides/experimental-feature-docs.md
+++ b/src/content/docs/guides/experimental-feature-docs.md
@@ -3,6 +3,99 @@ title: Adding docs for experimental features
 description: A guide to writing docs for your feature released behind an experimental flag.
 ---
 
+Features released behind an experimental flag allow our developers to work quickly, respond to feedback, and even change features entirely, with as little disruption to the Astro community as possible. These features are not required to follow our normal [semantic versioning rules](https://docs.astro.build/en/upgrade-astro/#semantic-versioning) and may introduce breaking changes without notice.
+
+## Documenting experimental features
+
+We keep an experimental feature's official documentation in Astro docs minimal, and scoped to the [experimental flag section of the configuration reference page](https://docs.astro.build/en/reference/configuration-reference/#experimental-flags). Only when a feature is no longer experimental do we add documentation within other pages. This gives us the greatest flexibility for things to change and evolve, as most experimental features do!
+
+### Where to add your documentation
+
+Documentation to the configuration reference page is added **in the main astro repo** to [`astro/packages/astro/src/@types/astro.ts`](https://github.com/withastro/astro/blob/main/packages/astro/src/%40types/astro.ts). You can find the section for experimental flags by searching for this line: `@name Experimental Flags`.
+
+### JSDoc format
+
+Add a new entry with the following structure:
+
+```ts
+/**
+		 * @docs
+		 * @name experimental.feature
+		 * @type {boolean}
+		 * @default `false`
+		 * @version 4.8.0
+		 * @description
+		 *
+		 * This feature [does/allows you to...]
+     * 
+     * To enable this feature, add the experimental flag in your Astro config:
+		 *
+		 * ```js
+		 * {
+		 *   experimental: {
+		 *     feature: true,
+		 *   },
+		 * }
+		 * ```
+		 *
+		 * Describe any required configuration, as well as basic usage here.
+     * It's OK if this is 100 lines or so!
+     * This will be the only documentation in docs!
+     * The RFC will do most of the docs "heavy lifting."
+     * 
+		 * For a complete overview, and to give feedback on this experimental API,
+     * see the [Feature RFC](https://github.com/withastro/roadmap/blob/actions/proposals/00xx-feature.md).
+		 */
+		actions?: boolean;
+
+```
+
+### What to include in the description
+
+The description must include
+
+- A short description of what the feature does or allows you to do. (1 - 4 sentences)
+- `To enable this feature, add the experimental flag in your Astro config:` (1 line)
+- A minimal code example showing your experimental feature flag set to `true` (code block)
+- Any **required** configuration that must be set, with code sample showing a possible configuration (if applicable)
+	- (Code block prefaced by description such as "The following configuration sets...")
+- Minimal usage description and examples (aim for 100 lines max)
+	- Think of this as your **traditional documentation** section.
+	- Include the basics of what someone needs to get started/use the feature.
+	- Keep explanations short, and stick to common, basic examples.
+	- Do not try to cover every case/example.
+	- No hard maximum length, take the space you truly need.
+	- 
+
+
+
+### Why we document differently
+
+The development of these features emphasizes responsiveness and experimentation, so it is difficult to keep documentation up to date and translated. In some cases, experimental features behind a flag come with little or no documentation at all because we are not guaranteeing any stability: neither how, nor *that*, it works! We are happy to have people use and test these features, but our goal is *building* and not *delivering* at this stage of development.
+
+In fact, the best resource for experimental features is the RFC (request for consideration) proposal document and discussion thread. This allows a reader to follow the progress of a feature's *intention*, and how its implementation may have changed over time. This also allows engagement from the community, providing a place for questions and feedback before decisions are finalized.
+
+Other reasons for not documenting experimental features in regular docs pages include:
+
+- Removing the burden of the feature developer to write documentation to the standards and conventions of Astro Docs. The RFC proposal documents evolve, and are added to (not revised) as the feature changes. Astro docs must contstantly **update** to only show the most current, accurate information.
+
+- Many people choose to wait until experimental features are stable before trying them. Keeping the docs limited to only the latest stable version of Astro's fully-supported features is less confusing for most people.
+
+- Astro docs regularly receives PRs to update and correct information as they discover errors. Our repository activity is extremely high, and any perceived ommission or imperfection in our docs is noticed by our community adds extra workload to our docs team. While a feature may be experimental, docs itself is expected to be a stable, polished project. We can only achieve this once a feature has stabilized.
+
+- The lack of official documentation sets appropriate expectations surrounding support. Issues and support questions can be pointed to the RFC discussions instead of GitHub or Discord. It is not an "issue" if something isn't working in an experimental feature. It's not necessarily intended to work perfectly yet! But, getting feedback about a feature's performance or behaviour in the discussion thread is very helpful to the developers.
+
+And lastly, there's some benefit to experimental features feeling... experimental! Insider secrets! I have to go into Ben's mind to get the docs! I can participate in a roadmap discussion! We want our community to feel involved in the **process** whenever possible, as part of the team.
+
+
+## Experimental flag brain dump
+
+
+It just 
+
+
+
+
 ## Unflagging an experimental feature 
 
 Key things:
@@ -17,8 +110,7 @@ Key things:
 
 - link to finding more info in the docs
 
-Example:
-
+### Example
 
 The `i18nDomains` routing feature introduced behind a flag in [v3.4.0](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md#430) is no longer experimental and is available for general use.
 

--- a/src/content/docs/guides/experimental-feature-docs.mdx
+++ b/src/content/docs/guides/experimental-feature-docs.mdx
@@ -109,11 +109,11 @@ Add the following underneath the `@description` tag, in order:
 
 Congratulations, your feature is ready for release!
 
-Now, your documentation will live somewhere else in Astro Docs (Team Docs will guide you!) and the experimental flag will be removed from our Configuration Reference page.
+Now, your documentation will live somewhere else in Astro Docs (Team Docs will guide you through a separate docs PR!) and the experimental flag will be removed from our Configuration Reference page.
 
 ### Changeset
 
-The biggest docs task for this PR will be the changeset `.md` file that describes this PR for the CHANGELOG.
+After removing your experimental documentation from `astro.ts` completely, the biggest docs task for **this PR** will be the changeset `.md` file that describes this PR for the CHANGELOG. 
 
 Create a changeset using the following structure:
 

--- a/src/content/docs/guides/experimental-feature-docs.mdx
+++ b/src/content/docs/guides/experimental-feature-docs.mdx
@@ -1,5 +1,5 @@
 ---
-title: Adding docs for experimental features
+title: Adding docs for experimental flags
 description: A guide to writing docs for your feature released behind an experimental flag.
 ---
 import { Steps, Icon } from '@astrojs/starlight/components';

--- a/src/content/docs/guides/experimental-feature-docs.mdx
+++ b/src/content/docs/guides/experimental-feature-docs.mdx
@@ -2,12 +2,16 @@
 title: Adding docs for experimental features
 description: A guide to writing docs for your feature released behind an experimental flag.
 ---
+import { Steps, Icon } from '@astrojs/starlight/components';
+import ReadMore from '../../../components/ReadMore.astro'
 
 Features released behind an experimental flag allow our developers to work quickly, respond to feedback, and even change features entirely, with as little disruption to the Astro community as possible. These features are not required to follow our normal [semantic versioning rules](https://docs.astro.build/en/upgrade-astro/#semantic-versioning) and may introduce breaking changes without notice.
 
 ## Documenting experimental features
 
 We keep an experimental feature's official documentation in Astro docs minimal, and scoped to the [experimental flag section of the configuration reference page](https://docs.astro.build/en/reference/configuration-reference/#experimental-flags). Only when a feature is no longer experimental do we add documentation within other pages. This gives us the greatest flexibility for things to change and evolve, as most experimental features do!
+
+<ReadMore>Read more about [why we document experimental features differently](#why-we-document-differently)!</ReadMore>
 
 ### Where to add your documentation
 
@@ -52,22 +56,38 @@ Add a new entry with the following structure:
 
 ### What to include in the description
 
-The description must include
+Follow the steps below to craft your description, adding, in order:
+<Steps>
+1. A short description of **what the feature does** or **allows you to do**. (1 - 4 sentences)
 
-- A short description of what the feature does or allows you to do. (1 - 4 sentences)
-- `To enable this feature, add the experimental flag in your Astro config:` (1 line)
-- A minimal code example showing your experimental feature flag set to `true` (code block)
-- Any **required** configuration that must be set, with code sample showing a possible configuration (if applicable)
-	- (Code block prefaced by description such as "The following configuration sets...")
-- Minimal usage description and examples (aim for 100 lines max)
-	- Think of this as your **traditional documentation** section.
-	- Include the basics of what someone needs to get started/use the feature.
-	- Keep explanations short, and stick to common, basic examples.
+2. `To enable this feature, add the experimental flag in your Astro config:` (1 line)
+
+3. A minimal code example showing your experimental feature flag set to `true` (code block)
+
+4. Any **required** configuration that must be set, with code sample demonstrating a possible configuration (if applicable)
+	- Introduce the code block with a description such as "The following configuration sets [X and Y]."
+
+
+5. Mention **general requirements/limitations** or situations where this feature does not work. (if applicable)
+	- Do not be overly specific, but do let the reader know if there are general requirements.
+	- e.g. "This feature is not available on prerendered pages."
+
+
+6. Minimal usage description and examples (aim for 100 lines max)
+	- Think of this as your traditional documentation section.
+	- Keep explanations short, focused on getting someone started.
+	- If included, stick to showing only common, basic examples.
 	- Do not try to cover every case/example.
-	- No hard maximum length, take the space you truly need.
-	- 
+	- No strict maximum length; take the space you truly need.
 
 
+7. The following two lines to direct readers to the RFC for your feature, replacing the name and link with your own. (2 lines)
+		```js
+		* For a complete overview, and to give feedback on this experimental API,
+    * see the [Feature Name RFC](link to RFC proposal).
+		```
+
+</Steps>
 
 ### Why we document differently
 
@@ -85,15 +105,7 @@ Other reasons for not documenting experimental features in regular docs pages in
 
 - The lack of official documentation sets appropriate expectations surrounding support. Issues and support questions can be pointed to the RFC discussions instead of GitHub or Discord. It is not an "issue" if something isn't working in an experimental feature. It's not necessarily intended to work perfectly yet! But, getting feedback about a feature's performance or behaviour in the discussion thread is very helpful to the developers.
 
-And lastly, there's some benefit to experimental features feeling... experimental! Insider secrets! I have to go into Ben's mind to get the docs! I can participate in a roadmap discussion! We want our community to feel involved in the **process** whenever possible, as part of the team.
-
-
-## Experimental flag brain dump
-
-
-It just 
-
-
+And lastly, there's some benefit to experimental features feeling... experimental! Insider secrets! I have to go into Ben's mind to get the docs! I can participate in a roadmap discussion! We want our community to feel involved in the **process** whenever possible, as part of the team. (And, if *we* have to go ask Ben how this works, then our community "gets to", too!)
 
 
 ## Unflagging an experimental feature 

--- a/src/content/docs/guides/experimental-feature-docs.mdx
+++ b/src/content/docs/guides/experimental-feature-docs.mdx
@@ -5,11 +5,11 @@ description: A guide to writing docs for your feature released behind an experim
 import { Steps, Icon } from '@astrojs/starlight/components';
 import ReadMore from '../../../components/ReadMore.astro'
 
-Features released behind an experimental flag allow our developers to work quickly, respond to feedback, and even change features entirely, with as little disruption to the Astro community as possible. These features are not required to follow our normal [semantic versioning rules](https://docs.astro.build/en/upgrade-astro/#semantic-versioning) and may introduce breaking changes without notice.
+Features released behind an experimental flag allow our developers to work quickly, respond to feedback, and even change features entirely with as little disruption to the Astro community as possible. These features are not required to follow our normal [semantic versioning rules](https://docs.astro.build/en/upgrade-astro/#semantic-versioning) and may introduce breaking changes without notice.
 
 ## Documenting experimental features
 
-We keep an experimental feature's official documentation in Astro docs minimal, and scoped to the [experimental flag section of the configuration reference page](https://docs.astro.build/en/reference/configuration-reference/#experimental-flags).
+We only include minimal documentation in Astro docs, and keep it scoped to the [experimental flag section of the configuration reference page](https://docs.astro.build/en/reference/configuration-reference/#experimental-flags).
 
 Only when a feature is no longer experimental do we add documentation within other pages. This gives us the greatest flexibility for things to change and evolve, as most experimental features do!
 
@@ -107,39 +107,78 @@ Add the following underneath the `@description` tag, in order:
 
 ## Unflagging an experimental feature 
 
-Key things:
+Congratulations, your feature is ready for release!
 
-- noting when this experimental flag was first introduced (there might be some helpful context for someone just now learning about this in case they wants to look up what we said about this when it was first released, either in the changelog or blog post)
+Now, your documentation will live somewhere else in Astro Docs (Team Docs will guide you!) and the experimental flag will be removed from our Configuration Reference page.
 
-- a description of what it is, because it is now essentially a "new feature" of Astro! (I took from the earlier changelog for an example) and some people ignore experimental features. They might have no idea what this is, and it deserves just as much description/fanfare as when it was released as experimental!
+### Changeset
 
-- "If you were using this feature..." and code showing removing the experimental flag. (Prompt because this may break projects)
+The biggest docs task for this PR will be the changeset `.md` file that describes this PR for the CHANGELOG.
 
-- "If you have been waiting for stabilization before using.... , you can now do so." (Reminding them that maybe they saw this before and thought, "I'll wait!")
+Create a changeset using the following structure:
 
-- link to finding more info in the docs
+``````md wrap=true
+---
+"astro": minor
+---
 
-### Example
+The `myFeature` feature introduced behind a flag in [vx.x.0](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md#xx0) is no longer experimental and is available for general use.
 
-The `i18nDomains` routing feature introduced behind a flag in [v3.4.0](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md#430) is no longer experimental and is available for general use.
+// Hype your feature!
+// Use content from the original changeset and docs `@description`
+This [feature description] allows you to ....
 
-This routing option allows you to configure different domains for individual locales in entirely server-rendered projects using the [@astrojs/node](https://docs.astro.build/en/guides/integrations-guide/node/) or [@astrojs/vercel](https://docs.astro.build/en/guides/integrations-guide/vercel/) adapter with a `site` configured.
-
-If you were using this feature, please remove the experimental flag from your Astro config:
+If you were previously using this feature, please remove the experimental flag from your Astro config:
 
 ```diff
 import { defineConfig } from 'astro'
 
 export default defineConfig({
 -  experimental: {
--    i18nDomains: true,
+-    myFeature: true,
 -  }
 })
 ```
 
-If you have been waiting for stabilization before using this routing option, you can now do so. 
+If you have been waiting for stabilization before using this [feature description], you can now do so. 
 
-Please see [the internationalization docs](https://docs.astro.build/en/guides/internationalization/#domains) for more about this feature.
+Please see [the specific page in docs](https://docs.astro.build/en/my-feature/) for more about this feature.
+``````
+
+### What to include in the changeset
+
+Add the following underneath the frontmatter, in order:
+
+<Steps>
+1. `The [feature description] introduced behind a flag in [vx.x.0](https://github.com/withastro/astro/blob/main/packages/astro/CHANGELOG.md#xx0) is no longer experimental and is available for general use.` (1 line)
+2. **Reused content** from the experimental release changeset, as well as the `@description` from your experimental flag's documentation in `astro.ts`. (aim for 100 lines max)
+	- Remember, for some readers this *is* the (only) feature release! Be as descriptive as you were when it was experimental!
+	- This "introduces" your feature for the first time.
+	- This can include basic configuration, usage, and examples.
+	- Be sure to check for accuracy, and update as necessary to reflect the current state of the feature.
+	- No strict maximum length; take the space you truly need.
+
+2. `If you were previously using this feature, please remove the experimental flag from your Astro config:` (1 line)
+
+3. A minimal `diff` code example showing your experimental feature flag removed from Astro config. (code block)
+		```diff
+		import { defineConfig } from 'astro'
+
+		export default defineConfig({
+		-  experimental: {
+		-    myFeature: true,
+		-  }
+		})
+		```
+
+4. The following lines to emphasize stability and direct readers to the documentation for feature, replacing the name and link with your own. (2 lines)
+		```md wrap
+		If you have been waiting for stabilization before using this [feature description], you can now do so.
+
+		Please see [the specific page in docs](https://docs.astro.build/en/my-feature/) for more about this feature.
+		```
+</Steps>
+
 
 ## Why we document differently
 

--- a/src/content/docs/guides/experimental-feature-docs.mdx
+++ b/src/content/docs/guides/experimental-feature-docs.mdx
@@ -9,7 +9,9 @@ Features released behind an experimental flag allow our developers to work quick
 
 ## Documenting experimental features
 
-We keep an experimental feature's official documentation in Astro docs minimal, and scoped to the [experimental flag section of the configuration reference page](https://docs.astro.build/en/reference/configuration-reference/#experimental-flags). Only when a feature is no longer experimental do we add documentation within other pages. This gives us the greatest flexibility for things to change and evolve, as most experimental features do!
+We keep an experimental feature's official documentation in Astro docs minimal, and scoped to the [experimental flag section of the configuration reference page](https://docs.astro.build/en/reference/configuration-reference/#experimental-flags).
+
+Only when a feature is no longer experimental do we add documentation within other pages. This gives us the greatest flexibility for things to change and evolve, as most experimental features do!
 
 <ReadMore>Read more about [why we document experimental features differently](#why-we-document-differently)!</ReadMore>
 
@@ -27,7 +29,7 @@ Add a new entry with the following structure:
 		 * @name experimental.feature
 		 * @type {boolean}
 		 * @default `false`
-		 * @version 4.8.0
+		 * @version 4.x.0
 		 * @description
 		 *
 		 * This feature [does/allows you to...]
@@ -37,7 +39,7 @@ Add a new entry with the following structure:
 		 * ```js
 		 * {
 		 *   experimental: {
-		 *     feature: true,
+		 *     featureName: true,
 		 *   },
 		 * }
 		 * ```
@@ -56,24 +58,38 @@ Add a new entry with the following structure:
 
 ### What to include in the description
 
-Follow the steps below to craft your description, adding, in order:
+Add the following underneath the `@description` tag, in order:
 <Steps>
 1. A short description of **what the feature does** or **allows you to do**. (1 - 4 sentences)
 
 2. `To enable this feature, add the experimental flag in your Astro config:` (1 line)
 
-3. A minimal code example showing your experimental feature flag set to `true` (code block)
+3. A minimal code example showing your experimental feature flag set to `true`. (code block)
+		```js
+		{
+		 experimental: {
+		  featureName: true,
+		 },
+		}
+		```
+	- Include any **required** configuration that must be also be set. (if applicable)
+	- For example, if your feature requires on-demand rendering, include the `output` config:
+		```js ins={2}
+		{
+		 output: 'hybrid', // or 'server'
+		 experimental: {
+		  featureName: true,
+		 },
+		}
+		```
 
-4. Any **required** configuration that must be set, with code sample demonstrating a possible configuration (if applicable)
-	- Introduce the code block with a description such as "The following configuration sets [X and Y]."
 
-
-5. Mention **general requirements/limitations** or situations where this feature does not work. (if applicable)
+4. Mention **general requirements/limitations** or situations where this feature does not work. (if applicable)
 	- Do not be overly specific, but do let the reader know if there are general requirements.
-	- e.g. "This feature is not available on prerendered pages."
+	- For example, "This feature is not available on prerendered pages."
 
 
-6. Minimal usage description and examples (aim for 100 lines max)
+5. Minimal usage description and examples (aim for 100 lines max)
 	- Think of this as your traditional documentation section.
 	- Keep explanations short, focused on getting someone started.
 	- If included, stick to showing only common, basic examples.
@@ -81,32 +97,13 @@ Follow the steps below to craft your description, adding, in order:
 	- No strict maximum length; take the space you truly need.
 
 
-7. The following two lines to direct readers to the RFC for your feature, replacing the name and link with your own. (2 lines)
+6. The following two lines to direct readers to the RFC for your feature, replacing the name and link with your own. (2 lines)
 		```js
 		* For a complete overview, and to give feedback on this experimental API,
     * see the [Feature Name RFC](link to RFC proposal).
 		```
 
 </Steps>
-
-### Why we document differently
-
-The development of these features emphasizes responsiveness and experimentation, so it is difficult to keep documentation up to date and translated. In some cases, experimental features behind a flag come with little or no documentation at all because we are not guaranteeing any stability: neither how, nor *that*, it works! We are happy to have people use and test these features, but our goal is *building* and not *delivering* at this stage of development.
-
-In fact, the best resource for experimental features is the RFC (request for consideration) proposal document and discussion thread. This allows a reader to follow the progress of a feature's *intention*, and how its implementation may have changed over time. This also allows engagement from the community, providing a place for questions and feedback before decisions are finalized.
-
-Other reasons for not documenting experimental features in regular docs pages include:
-
-- Removing the burden of the feature developer to write documentation to the standards and conventions of Astro Docs. The RFC proposal documents evolve, and are added to (not revised) as the feature changes. Astro docs must contstantly **update** to only show the most current, accurate information.
-
-- Many people choose to wait until experimental features are stable before trying them. Keeping the docs limited to only the latest stable version of Astro's fully-supported features is less confusing for most people.
-
-- Astro docs regularly receives PRs to update and correct information as they discover errors. Our repository activity is extremely high, and any perceived ommission or imperfection in our docs is noticed by our community adds extra workload to our docs team. While a feature may be experimental, docs itself is expected to be a stable, polished project. We can only achieve this once a feature has stabilized.
-
-- The lack of official documentation sets appropriate expectations surrounding support. Issues and support questions can be pointed to the RFC discussions instead of GitHub or Discord. It is not an "issue" if something isn't working in an experimental feature. It's not necessarily intended to work perfectly yet! But, getting feedback about a feature's performance or behaviour in the discussion thread is very helpful to the developers.
-
-And lastly, there's some benefit to experimental features feeling... experimental! Insider secrets! I have to go into Ben's mind to get the docs! I can participate in a roadmap discussion! We want our community to feel involved in the **process** whenever possible, as part of the team. (And, if *we* have to go ask Ben how this works, then our community "gets to", too!)
-
 
 ## Unflagging an experimental feature 
 
@@ -143,3 +140,21 @@ export default defineConfig({
 If you have been waiting for stabilization before using this routing option, you can now do so. 
 
 Please see [the internationalization docs](https://docs.astro.build/en/guides/internationalization/#domains) for more about this feature.
+
+## Why we document differently
+
+The development of these features emphasizes responsiveness and experimentation, so it is difficult to keep documentation up to date and translated. In some cases, experimental features behind a flag come with little or no documentation at all because we are not guaranteeing any stability: neither how, nor *that*, it works! We are happy to have people use and test these features, but our goal is *building* and not *delivering* at this stage of development.
+
+In fact, the best resource for experimental features is the RFC (request for consideration) proposal document and discussion thread. This allows a reader to follow the progress of a feature's *intention*, and how its implementation may have changed over time. This also allows engagement from the community, providing a place for questions and feedback before decisions are finalized.
+
+Other reasons for not documenting experimental features in regular docs pages include:
+
+- Removing the burden of the feature developer to write documentation to the standards and conventions of Astro Docs. The RFC proposal documents evolve, and are added to (not revised) as the feature changes. Astro docs must contstantly **update** to only show the most current, accurate information.
+
+- Many people choose to wait until experimental features are stable before trying them. Keeping the docs limited to only the latest stable version of Astro's fully-supported features is less confusing for most people.
+
+- Astro docs regularly receives PRs to update and correct information as they discover errors. Our repository activity is extremely high, and any perceived ommission or imperfection in our docs is noticed by our community adds extra workload to our docs team. While a feature may be experimental, docs itself is expected to be a stable, polished project. We can only achieve this once a feature has stabilized.
+
+- The lack of official documentation sets appropriate expectations surrounding support. Issues and support questions can be pointed to the RFC discussions instead of GitHub or Discord. It is not an "issue" if something isn't working in an experimental feature. It's not necessarily intended to work perfectly yet! But, getting feedback about a feature's performance or behaviour in the discussion thread is very helpful to the developers.
+
+And lastly, there's some benefit to experimental features feeling... experimental! Insider secrets! I have to go into Ben's mind to get the docs! I can participate in a roadmap discussion! We want our community to feel involved in the **process** whenever possible, as part of the team. (And, if *we* have to go ask Ben how this works, then our community "gets to", too!)


### PR DESCRIPTION
This PR adds a new page with guidance on documenting a feature behind an experimental flag, and then what happens when the feature is unflagged!

Also duplicates the `<ReadMore>` component from Astro Docs so I can use it.