### PR TITLE
fix: typo in pull-requests.mdx

### DIFF
--- a/src/content/docs/docs-for-code-changes/pull-requests.mdx
+++ b/src/content/docs/docs-for-code-changes/pull-requests.mdx
@@ -60,7 +60,7 @@ The source content for Astro's documentation lives within two different reposito
 
     - A full list of all the English error messages, found here: https://github.com/withastro/astro/blob/main/packages/astro/src/core/errors/errors-data.ts
 
-2. All other content, including all non-English lanaguage content, is found within the Astro docs repo itself: https://github.com/withastro/docs 
+2. All other content, including all non-English language content, is found within the Astro docs repo itself: https://github.com/withastro/docs 
 
 Be sure to fill out the PR template for the docs repo, which will allow you to link an implementation PR to a corresponding docs PR.
 


### PR DESCRIPTION
* Fixes a small typo in `pull-requests.mdx` (`lanaguage` > `language`).