### PR TITLE
Add Hacktoberfest guide

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -82,7 +82,7 @@ export default defineConfig({
 						{ label: 'Adding a new Astro + X Guide', link: '/guides/new-third-party-stub/' },
 						{ label: 'Contributing a Recipe', link: '/guides/recipe-writing/' },
 						{ label: 'Translating Astro docs', link: '/guides/i18n/' },	
-						{ label: 'Contributing on Hacktoberfest', link: '/guides/hacktoberfest/' },
+						{ label: 'Contributing for Hacktoberfest', link: '/guides/hacktoberfest/' },
 					],
 				},
 				{

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -82,6 +82,7 @@ export default defineConfig({
 						{ label: 'Adding a new Astro + X Guide', link: '/guides/new-third-party-stub/' },
 						{ label: 'Contributing a Recipe', link: '/guides/recipe-writing/' },
 						{ label: 'Translating Astro docs', link: '/guides/i18n/' },	
+						{ label: 'Contributing on Hacktoberfest', link: '/guides/hacktoberfest/' },
 					],
 				},
 				{

--- a/src/content/docs/guides/hacktoberfest.md
+++ b/src/content/docs/guides/hacktoberfest.md
@@ -6,9 +6,7 @@ description: Learn how to contribute to Astro during Hacktoberfest.
 [Hacktoberfest](https://hacktoberfest.com/about/) is an annual event during the month of October to encourage open-source contributions. If you've ever wanted to contribute to Astro, this is your opportunity. From beginner to experienced, from developer to low/no-code contributor, you're welcome!
 
 :::note
-Since Hacktoberfest happens once a year during October, assume the information on this page to be only valid and up-to-date during October of each year.
-
-Things such as participating repos, rules, instructions, rewards, and so on may vary from year to year.
+Participating Astro repositories, rules, instructions, and rewards may vary from year to year. Please consult this guide for up-to-date information every October!
 :::
 
 ## Join the fest
@@ -19,23 +17,29 @@ To take part in Hacktoberfest, here's all you need to do:
 2. Make any [valid contributions](#contributions) following [Hacktoberfest's rules](https://hacktoberfest.com/participation/#pr-mr-details) during October.
 3. Let us know you're participating by requesting your PRs to be labeled as `hacktoberfest-accepted`.
 
-## Primer on open-source
+## How to contribute to open-source
 
-Especially for first-time contributors, open-source can be quite frightening -- but don't worry, we're here to help you succeed! Here are a few reliable resources you can read to get up to speed on the matter:
+Especially for first-time contributors, open-source can be quite frightening -- but don't worry, we're here to help you succeed! 
+
+In addition to [our own resources for first-time contributors](/first-time/1-about/), here are a few reliable resources to help you prepare for your first Hacktoberfest contributions:
 
 - [What is open-source](https://www.digitalocean.com/community/tutorials/what-is-open-source)
 - [How to contribute to open-source](https://opensource.guide/how-to-contribute/)
 - [How to use Git](https://www.digitalocean.com/community/cheatsheets/how-to-use-git-a-reference-guide)
 - [Getting started with GitHub Desktop](https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop)
 
-## Contributions
+## Allowed contributions
 
-Any contribution to [participating repositories](#participating-repositories) will be considered and count towards Hacktoberfest. Our only exceptions are contributions that are either spam attempts or that have no quality and effort.
+Astro welcomes contributions of all sizes from contributors of any experience level to this year's [participating repositories](#participating-repositories). **To be considered for Hacktoberfest credit, the contribution must improve the quality of the repository with a helpful addition, improvement, or fix.**
+
+Small fixes such as correcting typos are welcome and appreciated! Larger contributions such as translating a page of documentation or submitting a fix to an existing issue may also count towards Hacktoberfest totals if the PR can be reviewed and merged during the month of October.
+
+We will be closing PRs that do not meet our quality standards. Spam submissions will not be tolerated, and may result in being banned from the repo.
 
 :::caution
-AI contributions will not be accepted. Hacktoberfest exists to incentivize human contribution to open-source projects, and therefore, we cannot accept contributions that have been made by automated tools.
+**AI contributions will not be accepted.** Hacktoberfest exists to motivate and reward human contribution to open-source projects, and therefore, we cannot accept contributions that have been made by automated tools.
 
-This does not apply to AI assistance tools, such as GitHub Copilot or Cursor, that do not take over the core work of contributing from you.
+AI assistance tools, such as GitHub Copilot or Cursor, may be used to help you draft your contribution, but must be checked and edited for accuracy. If your submission contains obviously AI-generated errors, your PR will be rejected and you may be banned from further Hacktoberfest participation at our discretion.
 :::
 
 ## Participating repositories
@@ -50,14 +54,14 @@ Here are some of the main ways you can contribute to it:
 - Helping [translate the documentation](http://contribute.docs.astro.build/guides/i18n/) in your language.
 - Tackling [open "good first issues"](https://github.com/withastro/docs/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) in the repository.
 
-:::note[TODO]
-Adding information on the other participating repositories, I need to confirm.
+:::note[Other repositories]
+Other Astro repositories may agree to add the `hacktoberfest-accepted` tag on a case-by-case basis.
 :::
 
 ## Rewards
 
-All participating contributors will get thematic [Hacktoberfest Astro Badges](https://astro.badg.es/achievements/hacktoberfest-merges/bronze/) that "level up" as you contribute. You can showcase your Astro badges in a daily updated profile card, like this one: 
+Astro allows you to earn [Hacktoberfest achievements on your Astro Badge](https://astro.badg.es/achievements/hacktoberfest-merges/bronze/) that "level up" as you contribute. Every contributor to Astro automatically has a profile card generated that tracks several achievements, like this one: 
 
 [![@jsparkdev Astro contributions](https://astro.badg.es/v2/contributor/jsparkdev.svg)](https://astro.badg.es/contributor/jsparkdev/)
 
-
+[Enter your GitHub username and find your own contributor badge!](https://astro.badg.es/contributors/)

--- a/src/content/docs/guides/hacktoberfest.md
+++ b/src/content/docs/guides/hacktoberfest.md
@@ -37,9 +37,9 @@ Small fixes such as correcting typos are welcome and appreciated! Larger contrib
 We will be closing PRs that do not meet our quality standards. Spam submissions will not be tolerated, and may result in being banned from the repo.
 
 :::caution
-**AI contributions will not be accepted.** Hacktoberfest exists to motivate and reward human contribution to open-source projects, and therefore, we cannot accept contributions that have been made by automated tools.
+**AI contributions will not be accepted.** Hacktoberfest exists to motivate and reward human contributions to open-source projects, and therefore, we cannot accept contributions that have been made by automated tools.
 
-AI assistance tools, such as GitHub Copilot or Cursor, may be used to help you draft your contribution, but must be checked and edited for accuracy. If your submission contains obviously AI-generated errors, your PR will be rejected and you may be banned from further Hacktoberfest participation at our discretion.
+AI assistance tools, such as GitHub Copilot or Cursor, may be used to help you draft your contribution but must be checked and edited for accuracy. If your submission contains obviously AI-generated errors, your PR will be rejected and you may be banned from further Hacktoberfest participation at our discretion.
 :::
 
 ## Participating repositories

--- a/src/content/docs/guides/hacktoberfest.md
+++ b/src/content/docs/guides/hacktoberfest.md
@@ -1,0 +1,63 @@
+---
+title: Hacktoberfest
+description: Learn how to contribute to Astro during Hacktoberfest.
+---
+
+[Hacktoberfest](https://hacktoberfest.com/about/) is an annual event during the month of October to encourage open-source contributions. If you've ever wanted to contribute to Astro, this is your opportunity. From beginner to experienced, from developer to low/no-code contributor, you're welcome!
+
+:::note
+Since Hacktoberfest happens once a year during October, assume the information on this page to be only valid and up-to-date during October of each year.
+
+Things such as participating repos, rules, instructions, rewards, and so on may vary from year to year.
+:::
+
+## Join the fest
+
+To take part in Hacktoberfest, here's all you need to do:
+
+1. Register for the event on [Hacktoberfest's official website](https://hacktoberfest.com/).
+2. Make any [valid contributions](#contributions) following [Hacktoberfest's rules](https://hacktoberfest.com/participation/#pr-mr-details) during October.
+3. Let us know you're participating by requesting your PRs to be labeled as `hacktoberfest-accepted`.
+
+## Primer on open-source
+
+Especially for first-time contributors, open-source can be quite frightening -- but don't worry, we're here to help you succeed! Here are a few reliable resources you can read to get up to speed on the matter:
+
+- [What is open-source](https://www.digitalocean.com/community/tutorials/what-is-open-source)
+- [How to contribute to open-source](https://opensource.guide/how-to-contribute/)
+- [How to use Git](https://www.digitalocean.com/community/cheatsheets/how-to-use-git-a-reference-guide)
+- [Getting started with GitHub Desktop](https://docs.github.com/en/desktop/overview/getting-started-with-github-desktop)
+
+## Contributions
+
+Any contribution to [participating repositories](#participating-repositories) will be considered and count towards Hacktoberfest. Our only exceptions are contributions that are either spam attempts or that have no quality and effort.
+
+:::caution
+AI contributions will not be accepted. Hacktoberfest exists to incentivize human contribution to open-source projects, and therefore, we cannot accept contributions that have been made by automated tools.
+
+This does not apply to AI assistance tools, such as GitHub Copilot or Cursor, that do not take over the core work of contributing from you.
+:::
+
+## Participating repositories
+
+### Astro Docs
+
+The [`withastro/docs` repository](https://github.com/withastro/docs) contains the complete source code and content for the [Astro documentation](https://docs.astro.build/) website in all the available languages.
+
+Here are some of the main ways you can contribute to it:
+
+- Reading the current or [5.0 beta docs](https://5-0-0-beta.docs.astro.build/) and fixing any typos, grammar issues, or missing information.
+- Helping [translate the documentation](http://contribute.docs.astro.build/guides/i18n/) in your language.
+- Tackling [open "good first issues"](https://github.com/withastro/docs/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) in the repository.
+
+:::note[TODO]
+Adding information on the other participating repositories, I need to confirm.
+:::
+
+## Rewards
+
+All participating contributors will get thematic [Hacktoberfest Astro Badges](https://astro.badg.es/achievements/hacktoberfest-merges/bronze/) that "level up" as you contribute. You can showcase your Astro badges in a daily updated profile card, like this one: 
+
+[![@jsparkdev Astro contributions](https://astro.badg.es/v2/contributor/jsparkdev.svg)](https://astro.badg.es/contributor/jsparkdev/)
+
+

--- a/src/content/docs/guides/hacktoberfest.md
+++ b/src/content/docs/guides/hacktoberfest.md
@@ -46,7 +46,7 @@ AI assistance tools, such as GitHub Copilot or Cursor, may be used to help you d
 
 ### Astro Docs
 
-The [`withastro/docs` repository](https://github.com/withastro/docs) contains the complete source code and content for the [Astro documentation](https://docs.astro.build/) website in all the available languages.
+[`withastro/docs`](https://github.com/withastro/docs) contains the complete source code and content for the [Astro documentation](https://docs.astro.build/) website in all the available languages.
 
 Here are some of the main ways you can contribute to it:
 

--- a/src/content/docs/guides/hacktoberfest.md
+++ b/src/content/docs/guides/hacktoberfest.md
@@ -54,6 +54,14 @@ Here are some of the main ways you can contribute to it:
 - Helping [translate the documentation](http://contribute.docs.astro.build/guides/i18n/) in your language.
 - Tackling [open "good first issues"](https://github.com/withastro/docs/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) in the repository.
 
+### Astro Adapters
+
+[/withastro/adapters](https://github.com/withastro/adapters) is the repository for Astro's official adapter integrations: Node.js, Netlify, Vercel, and Cloudflare.
+
+### Houston Discord Bot
+
+[/withastro/houston-discord](https://github.com/withastro/houston-discord) is Astro's own Houston, a bot made to make the life of everyone within the Astro community easier.
+
 :::note[Other repositories]
 Other Astro repositories may agree to add the `hacktoberfest-accepted` tag on a case-by-case basis.
 :::

--- a/src/content/docs/guides/hacktoberfest.md
+++ b/src/content/docs/guides/hacktoberfest.md
@@ -15,7 +15,7 @@ To take part in Hacktoberfest, here's all you need to do:
 
 1. Register for the event on [Hacktoberfest's official website](https://hacktoberfest.com/).
 2. Make any [valid contributions](#allowed-contributions) following [Hacktoberfest's rules](https://hacktoberfest.com/participation/#pr-mr-details) during October.
-3. Let us know you're participating by requesting your PRs to be labeled as `hacktoberfest-accepted`.
+3. Let us know you're participating by requesting the PRs label `hacktoberfest-accepted`.
 
 ## How to contribute to open-source
 

--- a/src/content/docs/guides/hacktoberfest.md
+++ b/src/content/docs/guides/hacktoberfest.md
@@ -52,15 +52,21 @@ Here are some of the main ways you can contribute to it:
 
 - Reading the current or [5.0 beta docs](https://5-0-0-beta.docs.astro.build/) and fixing any typos, grammar issues, or missing information.
 - Helping [translate the documentation](http://contribute.docs.astro.build/guides/i18n/) in your language.
-- Tackling [open "good first issues"](https://github.com/withastro/docs/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) in the repository.
+- Tackling open [ "good first issues"](https://github.com/withastro/docs/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) (or if you're more familiar with Astro, ["help wanted"](https://github.com/withastro/docs/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) issues) in the repository.
 
 ### Astro Adapters
 
-[/withastro/adapters](https://github.com/withastro/adapters) is the repository for Astro's official adapter integrations: Node.js, Netlify, Vercel, and Cloudflare.
+[`withastro/adapters`](https://github.com/withastro/adapters) is the repository for Astro's official adapter integrations: Node.js, Netlify, Vercel, and Cloudflare.
 
 ### Houston Discord Bot
 
-[/withastro/houston-discord](https://github.com/withastro/houston-discord) is Astro's own Houston, a bot made to make the life of everyone within the Astro community easier.
+[`withastro/houston-discord`](https://github.com/withastro/houston-discord) is Astro's own Houston, a bot made to make the life of everyone within the Astro community easier.
+
+### Starlight
+
+[`withastro/starlight`](https://github.com/withastro/docs) is a full-featured documentation theme built on top of the Astro framework.
+
+You can contribute to the Starlight theme by improving the [documentation](https://starlight.astro.build/) by fixing typos, grammar issues, missing information or by helping [translate](https://github.com/withastro/starlight/blob/main/CONTRIBUTING.md#translations) Starlight’s UI or documentation in your language.
 
 :::note[Other repositories]
 Other Astro repositories may agree to add the `hacktoberfest-accepted` tag on a case-by-case basis.

--- a/src/content/docs/guides/hacktoberfest.md
+++ b/src/content/docs/guides/hacktoberfest.md
@@ -14,7 +14,7 @@ Participating Astro repositories, rules, instructions, and rewards may vary from
 To take part in Hacktoberfest, here's all you need to do:
 
 1. Register for the event on [Hacktoberfest's official website](https://hacktoberfest.com/).
-2. Make any [valid contributions](#contributions) following [Hacktoberfest's rules](https://hacktoberfest.com/participation/#pr-mr-details) during October.
+2. Make any [valid contributions](#allowed-contributions) following [Hacktoberfest's rules](https://hacktoberfest.com/participation/#pr-mr-details) during October.
 3. Let us know you're participating by requesting your PRs to be labeled as `hacktoberfest-accepted`.
 
 ## How to contribute to open-source

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -14,6 +14,9 @@ hero:
     - text: Read the Astro docs
       link: https://docs.astro.build
       icon: external
+banner:
+  content: |
+    <a href="/guides/hacktoberfest/">Come participate in this year's Hacktoberfest!</a>
 editUrl: false
 ---
 


### PR DESCRIPTION
This PR adds the Hacktoberfest guide to be shared as our official entry point to the event. Need to confirm which things to highlight and confirm the other participating repos.