### PR TITLE
Improve reference to maintainers in 'New or Updated Features' page

### DIFF
--- a/src/content/docs/docs-for-code-changes/new-feature-docs.mdx
+++ b/src/content/docs/docs-for-code-changes/new-feature-docs.mdx
@@ -52,9 +52,9 @@ You are not required to demonstrate all things possible, and in fact too many op
 
 Whenever you are thinking about how the user will use the feature!
 
-It can be useful to get docs involved when you're considering the **user experience** of the feature. For example, if you are creating a new configuration option, docs maintainers can help you look at look at things from a (new) user perspective: Does the name accurately describe the user intention and what they are trying to achieve (and not what the underlying code or logic is doing, which might be quite different)?
+It can be useful to get docs maintainers involved when you're considering the **user experience** of the feature. For example, if you are creating a new configuration option, docs maintainers can help you look at look at things from a (new) user perspective: Does the name accurately describe the user intention and what they are trying to achieve (and not what the underlying code or logic is doing, which might be quite different)?
 
-In this way, docs can get involved earlier than you think... As soon as you know what the user story is!
+In this way, docs maintainers can get involved earlier than you think... As soon as you know what the user story is!
 
 Docs maintainers can also help you by being an early "user" of the process and surface unmet user expectations, friction, or even possible errors while using the feature.
 
@@ -62,7 +62,7 @@ For example, if your code's logic *filters out* results in order to provide a li
 
 Docs maintainers can help identify a user's thinking based on **using the feature** instead of caring about the **underlying implementation of the feature**.
 
-## When is it too early to get docs involved?
+## When is it too early to get docs maintainers involved?
 
 When you can't yet picture how a user will use your feature! 
 


### PR DESCRIPTION
In several instances, the [New or Updated Features](https://contribute.docs.astro.build/docs-for-code-changes/new-feature-docs/) guide refers to "docs" when it means "docs maintainers." This PR updates those references to "docs maintainers" for better clarity and to ensure the intended audience is clear.