### PR TITLE
Add `<Meta />` component documentation

### DIFF
--- a/src/content/docs/first-time/pr-review-process.md
+++ b/src/content/docs/first-time/pr-review-process.md
@@ -24,7 +24,7 @@ Some automated checks will need to run to verify your code (check for broken lin
 
       - [ ] Does every component you are documenting (e.g. `<ViewTransitions />`) have code backticks around the component? Components must be written as inline code or else Astro will treat it as an actual component.
       - [ ] Do all [custom components](/reference/custom-components/), including [code samples](/reference/code-samples/), have proper syntax, both opening and closing? 
-      - [ ] Have you imported any components at the top of the file that you are using in the content? (e.g. `<Since />` or `<PackageManagerTab>`)
+      - [ ] Have you imported any components at the top of the file that you are using in the content? (e.g. `<Meta />` or `<PackageManagerTab>`)
 
 If you are able to identify and make the fix for a failing check yourself, please do! If you are unsure what is causing a check to fail, then you can wait for a maintainer's help to fix the problem.
 

--- a/src/content/docs/reference/api-references.md
+++ b/src/content/docs/reference/api-references.md
@@ -9,18 +9,14 @@ When adding or editing a reference entry, please start your entry with the follo
 ```astro
 ##### `page.url.first`
 
-<p>
-
-**Type:** `string | undefined`<br />
-<Since v="4.12.0" />
-</p>
+<Meta version="4.12.0">`string | undefined`</Meta>
 ```
 
 ## Things to check
 
 - The entry has a heading so that it can be directly linked to.
 - The heading text is the name of the property/item, formatted as inline code. (e.g. `getStaticPaths()`, `width`)
-- There is a wrapping `<p></p>` that includes an initial blank line, and then the type, default (if applicable), and version number added each on individual lines.
+- There is a `<Meta />` component that includes information about the type, default (if applicable), and version number.
 - The text entry starts with a **definition** of what the property **is** or **does**.
 
 ## Full API reference example
@@ -28,11 +24,7 @@ When adding or editing a reference entry, please start your entry with the follo
 ```astro wrap
 ### `navigate()`
 
-<p>
-
-**Type:** `(href: string, options?: Options) => void`<br />
-<Since v="3.2.0" />
-</p>
+<Meta version="3.2.0">`(href: string, options?: Options) => void`</Meta>
 
 A function that executes a navigation to the given `href` using the View Transitions API.
 
@@ -40,12 +32,9 @@ This function signature is based on the [`navigate` function from the browser Na
 
 #### `history`
 
-<p>
-
-**Type:** `'auto' | 'push' | 'replace'`<br />
-**Default:** `'auto'`<br />
-<Since v="3.2.0" />
-</p>
+<Meta default="`'auto'`" version="3.2.0">
+`'auto' | 'push' | 'replace'`
+</Meta>
 
 Defines how this navigation should be added to the browser history.
 

--- a/src/content/docs/reference/custom-components.mdx
+++ b/src/content/docs/reference/custom-components.mdx
@@ -33,7 +33,88 @@ By default, the badge uses a muted colour scheme to blend in. It also has an acc
 - The [Editor Setup](https://docs.astro.build/en/editor-setup/#other-code-editors) page uses `<Badge />` to distinguish community and official editor support.
 - The [Deployment guides navigation component](https://docs.astro.build/en/guides/deploy/) uses `<Badge />` internally to label the deployment types each service supports.
 
+### Meta Component
+
+As features are added to Astro, we document their *type*, their *default* value, their *cli* equivalent and *when* they were added. This allows users to easily see if the version of Astro (or other packages) they are running supports a specific feature as described in the docs.
+
+Use the `<Meta />` component to display this information in a standardized way.
+
+This component takes an optional child and four optional props. The child is used to describe the type of your feature. The props are the following:
+
+- an `availableFor` prop, which indicates under what circumstances the feature is available,
+- a `cli` prop, which indicates the corresponding CLI option for this feature,
+- A `pkg` prop, which indicates which package is being documented. This will default to `'astro'` and is only required when using `<Meta />` for other packages while specifying a version.
+- A `version` prop, which indicates the version of the package in which the feature was added.
+
+```mdx
+import Meta from '~/components/Meta.astro';
+
+<Meta>`boolean`</Meta>
+```
+
+This will render the text “**Type:** `boolean`”.
+
+The advantages of using the component include:
+
+- “Available for“, “Type“, “Default“, “CLI“ and “Added in” are automatically translated on pages in other languages.
+- You only need one component to document your feature and you don't need to worry about formatting.
+- The passed version is checked against the current package version and “NEW” or “BETA” badges will be added automatically based on data from npm.
+
+#### Examples
+
+The standard usage of this component is on its own line, immediately following the feature's heading, for example:
+
+```mdx
+## `Astro.clientAddress`
+
+<Meta version="1.0.0-rc" />
+
+Specifies the IP address of the request. This property is only available when building for SSR (server-side rendering) and should not be used for static sites.
+```
+
+Set a custom package name for integrations and other packages. These will begin with `@astrojs/`:
+
+```mdx
+<Meta pkg="@astrojs/rss" version="2.1.0" />
+```
+
+A more advanced usage might look like:
+
+```mdx
+### `devImageService`
+
+<Meta
+  availableFor="Serverless, Static"
+  default="`'sharp'`"
+  pkg="@astrojs/vercel"
+  version="3.8.0"
+>
+`'sharp' | 'squoosh' | string`
+</Meta>
+```
+
+Once rendered, the component will display the information like this:
+
+```
+Type: 'sharp' | 'squoosh' | string
+Default: 'sharp'
+Available for: Serverless, Static
+Added in: @astrojs/vercel@3.8.0
+```
+
+You can also use links in your type to refer to another section within the page:
+
+```
+#### `schema`
+
+<Meta>
+<code>ZodType | (context: <a href="#schemacontext">SchemaContext</a>) => ZodType</code>
+</Meta>
+```
+
 ### Since Component
+
+**Deprecated**: Instead, use the `<Meta />` component to document your feature.
 
 As features are added to Astro, we document *when* they were added. This allows users to easily see if the version of Astro (or other packages) they are running supports a specific feature as described in the docs.
 


### PR DESCRIPTION
## Context

A new component will be added to `withastro/docs` to help authoring new features in the documentation. You can learn more about the new component in https://github.com/withastro/docs/discussions/9498 and https://github.com/withastro/docs/pull/9513.

The PR is not yet validated so this is just a draft written in advance to avoid any confusion once validated. Further modifications may be necessary.

## Changes

* Adds `<Meta />` to the custom components page
* Adds a "Deprecated" note regarding the `<Since />` component (if we really want to encourage the use of a single component)
* Updates the examples in the "API references" page
* Replaces `<Since />` with `<Meta />` in the "PR reviews and merging" page (if we really want to encourage the use of a single component)