### PR TITLE
Add links to homepage cards

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -25,16 +25,34 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 ## Next steps
 
 <CardGrid stagger>
-	<Card title="Writing and Style Guides" icon="pencil">
-		Learn how to write text and code for Astro docs.
-	</Card>
-	<Card title="i18n and Translator guides" icon="add-document">
-		Add contributions to Astro docs in other languages.
-	</Card>
-	<Card title="Maintainer and Reviewer Guides" icon="setting">
-		Learn how to manage PRs in the Astro docs repo as a maintainer or reviewer.
-	</Card>
-	<Card title="Read the docs" icon="open-book">
-		Visit [Astro Docs](https://docs.astro.build/) to learn about Astro!
-	</Card>
+
+  <Card title="Writing and Style Guides" icon="pencil">
+  
+    Learn how to write text and code for Astro docs.
+
+    - [Astro Docs writing style](/guides/writing-style/)
+
+  </Card>
+
+  <Card title="i18n and Translator guides" icon="add-document">
+
+    Add contributions to Astro docs in other languages.
+
+    - [How to translate Astro’s docs](/guides/i18n/)
+    - [How to review translation PRs](/reviewers/reviewing-translations/)
+
+  </Card>
+
+  <Card title="Maintainer and Reviewer Guides" icon="setting">
+
+    Learn how to manage PRs in the Astro docs repo as a [maintainer](/roles/maintainers/) or [reviewer](/reviewers/0-reviewing-prs/).
+
+  </Card>
+  
+  <Card title="Read the docs" icon="open-book">
+  
+    Visit [Astro Docs](https://docs.astro.build/) to learn about Astro!
+
+  </Card>
+
 </CardGrid>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -43,6 +43,14 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
   </Card>
 
+  <Card title="Document changes to the Astro code base" icon="seti:html">
+
+    See how to add docs to accompany your Astro code PR.
+
+    - [Documenting code changes](/docs-for-code-changes/about-documenting-code-changes/)
+
+  </Card>
+
   <Card title="Maintainer and Reviewer Guides" icon="setting">
 
     Learn how to manage PRs in the Astro docs repo as a [maintainer](/roles/maintainers/) or [reviewer](/reviewers/0-reviewing-prs/).


### PR DESCRIPTION
Always bugged me that these cards mention specific guides but don’t link to them, so if you were interested you had to do detective work.

This PR adds explicit links to pages to each of the homepage cards that didn’t have this yet. Feel free to suggest alternate links instead of course if I got something wrong!