### PR TITLE
fix: Update Language Guides' location

### DIFF
--- a/src/content/docs/guides/i18n.mdx
+++ b/src/content/docs/guides/i18n.mdx
@@ -410,7 +410,7 @@ To make it easy to find and organize our i18n PRs for both maintainers and revie
 
 Translators are free to create and maintain a glossary, style guide, and other tips for their language's translation crew. This is a great way to keep translations consistent across contributors and to centralize team decisions. You can find it (or create it) inside the language's `i18n` folder as a `README.md` file.
 
-Feel free to take a look at the [Deutsch Guide](https://github.com/withastro/docs/blob/main/src/i18n/de/README.md) for an example.
+Feel free to take a look at the [Deutsch Guide](https://github.com/withastro/docs/blob/main/i18n-guides/deutsch.md) for an example.
 
 ### Tutorials
 

--- a/src/content/docs/guides/i18n.mdx
+++ b/src/content/docs/guides/i18n.mdx
@@ -408,7 +408,7 @@ To make it easy to find and organize our i18n PRs for both maintainers and revie
 
 ### Language Guides
 
-Translators are free to create and maintain a glossary, style guide, and other tips for their language's translation crew. This is a great way to keep translations consistent across contributors and to centralize team decisions. You can find it (or create it) inside the language's `i18n` folder as a `README.md` file.
+Translators are free to create and maintain a glossary, style guide, and other tips for their language's translation crew. This is a great way to keep translations consistent across contributors and to centralize team decisions. You can find it (or create it) inside `i18n-guides` folder as a `<language>.md` file.
 
 Feel free to take a look at the [Deutsch Guide](https://github.com/withastro/docs/blob/main/i18n-guides/deutsch.md) for an example.
 


### PR DESCRIPTION
Language Guides' links have changed since v5 released, so I update it.