### PR TITLE
Adds a changeset example

### DIFF
--- a/src/content/docs/docs-for-code-changes/changesets.md
+++ b/src/content/docs/docs-for-code-changes/changesets.md
@@ -32,7 +32,12 @@ Begin your changeset message with **a present tense verb** that completes a sent
 - Improves
 - Deprecates
 
-Finish the introductory sentence with a message focusing on what has changed that is meaningful to a **user** of Astro. It is usually more helpful to describe the change **as someone building an Astro site will experience it**, instead of describing **how you fixed it**.
+Finish the introductory sentence with a message focusing on what has changed **about the codebase** (not what your feature itself does) that is meaningful to a **user** of Astro. It is usually more helpful to describe the change **as someone building an Astro site will experience it**, instead of describing **how you fixed it** or **what the code in the PR does**:
+
+```markdown title="changeset.md" del={1} ins={2)
+Logs helpful errors if content is invalid
+Improves error reporting for content collections by adding logging for configuration errors that had previously been silently ignored.
+```
 
 You may then include additional paragraphs if necessary to describe the change in more detail. This may not be needed for a small bug fix, but is often helpful if the reader must make a change to their own code, or needs to understand how the change might affect them.
 

--- a/src/content/docs/docs-for-code-changes/changesets.md
+++ b/src/content/docs/docs-for-code-changes/changesets.md
@@ -34,9 +34,15 @@ Begin your changeset message with **a present tense verb** that completes a sent
 
 Finish the introductory sentence with a message focusing on what has changed **about the codebase** (not what your feature itself does) that is meaningful to a **user** of Astro. It is usually more helpful to describe the change **as someone building an Astro site will experience it**, instead of describing **how you fixed it** or **what the code in the PR does**:
 
-```markdown title="changeset.md" del={1} ins={2} wrap
+```markdown title="changeset.md" del={1,2} ins={4,5,6,8} wrap
+// What the code now does
 Logs helpful errors if content is invalid
+
+// The nature of the change to the Astro code base
+// Framed in terms of a user's experience
 Improves error reporting for content collections by adding logging for configuration errors that had previously been silently ignored.
+
+Adds logging for some content collections configuration errors that had previously been silently ignored.
 ```
 
 You may then include additional paragraphs if necessary to describe the change in more detail. This may not be needed for a small bug fix, but is often helpful if the reader must make a change to their own code, or needs to understand how the change might affect them.

--- a/src/content/docs/docs-for-code-changes/changesets.md
+++ b/src/content/docs/docs-for-code-changes/changesets.md
@@ -34,15 +34,12 @@ Begin your changeset message with **a present tense verb** that completes a sent
 
 Finish the introductory sentence with a message focusing on what has changed **about the codebase** (not what your feature itself does) that is meaningful to a **user** of Astro. It is usually more helpful to describe the change **as someone building an Astro site will experience it**, instead of describing **how you fixed it** or **what the code in the PR does**:
 
-```markdown title="changeset.md" del={2} ins={6,8} wrap
+```markdown title="changeset.md" del={2} ins={5}
 // What the code now does
 Logs helpful errors if content is invalid
 
 // The nature of the change to the Astro code base
-// Framed in terms of a user's experience
-Improves error reporting for content collections by adding logging for configuration errors that had previously been silently ignored.
-
-Adds logging for some content collections configuration errors that had previously been silently ignored.
+Adds logging for content collections configuration errors.
 ```
 
 You may then include additional paragraphs if necessary to describe the change in more detail. This may not be needed for a small bug fix, but is often helpful if the reader must make a change to their own code, or needs to understand how the change might affect them.

--- a/src/content/docs/docs-for-code-changes/changesets.md
+++ b/src/content/docs/docs-for-code-changes/changesets.md
@@ -34,7 +34,7 @@ Begin your changeset message with **a present tense verb** that completes a sent
 
 Finish the introductory sentence with a message focusing on what has changed **about the codebase** (not what your feature itself does) that is meaningful to a **user** of Astro. It is usually more helpful to describe the change **as someone building an Astro site will experience it**, instead of describing **how you fixed it** or **what the code in the PR does**:
 
-```markdown title="changeset.md" del={1} ins={2)
+```markdown title="changeset.md" del={1} ins={2} wrap
 Logs helpful errors if content is invalid
 Improves error reporting for content collections by adding logging for configuration errors that had previously been silently ignored.
 ```

--- a/src/content/docs/docs-for-code-changes/changesets.md
+++ b/src/content/docs/docs-for-code-changes/changesets.md
@@ -34,7 +34,7 @@ Begin your changeset message with **a present tense verb** that completes a sent
 
 Finish the introductory sentence with a message focusing on what has changed **about the codebase** (not what your feature itself does) that is meaningful to a **user** of Astro. It is usually more helpful to describe the change **as someone building an Astro site will experience it**, instead of describing **how you fixed it** or **what the code in the PR does**:
 
-```markdown title="changeset.md" del={1,2} ins={4,5,6,8} wrap
+```markdown title="changeset.md" del={2} ins={6,8} wrap
 // What the code now does
 Logs helpful errors if content is invalid
 


### PR DESCRIPTION
Includes some specific advice I've given a few times re: starting changesets with the verb that describes the kind of change to the codebase (e.g. adds, improves, refactors), vs what the code in the PR actually does (e.g. logs errors).