### PR TITLE
fix(hacktoberfest): remove Adapters section now they are in Core

### DIFF
--- a/src/content/docs/guides/hacktoberfest.md
+++ b/src/content/docs/guides/hacktoberfest.md
@@ -54,10 +54,6 @@ Here are some of the main ways you can contribute to it:
 - Helping [translate the documentation](http://contribute.docs.astro.build/guides/i18n/) in your language.
 - Tackling open [ "good first issues"](https://github.com/withastro/docs/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) (or if you're more familiar with Astro, ["help wanted"](https://github.com/withastro/docs/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) issues) in the repository.
 
-### Astro Adapters
-
-[`withastro/adapters`](https://github.com/withastro/adapters) is the repository for Astro's official adapter integrations: Node.js, Netlify, Vercel, and Cloudflare.
-
 ### Houston Discord Bot
 
 [`withastro/houston-discord`](https://github.com/withastro/houston-discord) is Astro's own Houston, a bot made to make the life of everyone within the Astro community easier.


### PR DESCRIPTION
## Changes

The `withastro/adapters` packages have moved back to `withastro/astro` and the repo is now archived. So, I removed that section from the `hacktoberfest` guide.