### PR TITLE
"What to translate" now lists required first pages

### DIFF
--- a/src/content/docs/guides/i18n.mdx
+++ b/src/content/docs/guides/i18n.mdx
@@ -200,7 +200,7 @@ Although it's a big project, we really value having our "Build a Blog" tutorial 
 
 The tutorial pages include learning-oriented guides on Astro and its features. These pages are especially seen by beginner Astro developers, complex terminology is kept to a minimum, and what is there is well-explained for beginners in small to medium-sized pages.
 
-Even though these pages may be small, they are cummulative, demanding more of translators and reviewers to keep a consistent language across all pages. Translators may need to look at past or future pages to ensure that they are using a consistent vocuabulary and phrasing. Tutorials are also constantly updated based on user feedback, meaning changes are more frequent but generally small and lesson-specific.
+Even though these pages may be small, they are cumulative, demanding more of translators and reviewers to keep a consistent language across all pages. Translators may need to look at past or future pages to ensure that they are using a consistent vocabulary and phrasing. Tutorials are also constantly updated based on user feedback, meaning changes are more frequent but generally small and lesson-specific.
 
 **The entire tutorial must be translated before any individual lesson pages can be published.** This is so that a reader does not have to switch languages from one page to the next as they are taking the tutorial, trying to learn Astro. When you are ready to start translating the tutorial, you must **ask for a branch to be created for you** (e.g. `/es-tutorial/`) and must make PRs to your tutorial branch, not to the main branch of Astro docs.
 

--- a/src/content/docs/guides/i18n.mdx
+++ b/src/content/docs/guides/i18n.mdx
@@ -260,19 +260,9 @@ The "Add-ons" pages explain Astro features and support that you can add by insta
 
 The "Integrations" pages are sub-pages available at the root "Add integrations" page. These considerably vary in size, maintenance cost, and complexity. The "UI Frameworks" integrations are smaller and easier to maintain, while the others average bigger sizes and are more bound to go through changes.
 
-The most viewed pages by category, by a considerable margin, the `@astrojs/react`, `@astrojs/node`, and `@astrojs/tailwind` pages.
+The most viewed pages by category, by a considerable margin, the `@astrojs/react` and `@astrojs/node` pages.
 
 Each integration page contains several specific terms about the integrated technology, increasing the translation complexity especially for those not familiar with it.
-
-#### Recipes
-
-- **View Count:** Medium
-- **Maintenance:** Super Low
-- **Size:** Extra Small
-
-The "Recipes" pages are portals to task-oriented, how-to guides from migrating to Astro from another technology to deploying to a specific platform.
-
-Since the content most users will look for is in the sub-pages, the root Recipe pages are one of the smallest and with less complexity of the whole documentation, being easy wins for any translators wanting to get some pages done quickly.
 
 #### Migrate to Astro
 
@@ -316,13 +306,13 @@ Deploying Astro to most hosting platforms is a straightforward task since many s
 
 As a whole, deploy guides are quick wins, not containing a lot of terminology and having small page sizes.
 
-#### More Recipes
+#### Recipes
 
 - **View Count:** Low
 - **Maintenance:** Low
 - **Size:** Medium
 
-The "More Recipes" guides include task-oriented guides based on several of Astro features and use cases, most pages are small, or rather, code-heavy, containing less complex terminology, making most of them quick wins for any translators, especially those not used to all of Astro's terminology yet thanks to the recipe's self-contained approach.
+The "Recipes" guides include task-oriented guides based on several of Astro features and use cases, most pages are small, or rather, code-heavy, containing less complex terminology, making most of them quick wins for any translators, especially those not used to all of Astro's terminology yet thanks to the recipe's self-contained approach.
 
 #### Guides
 

--- a/src/content/docs/guides/i18n.mdx
+++ b/src/content/docs/guides/i18n.mdx
@@ -175,9 +175,38 @@ Not all of our pages are ready for translation, we roll out new pages for transl
 
 ### What to translate
 
-You're free to choose the pages _you_ feel the most comfortable or excited about, but if you're asking yourself "What should I translate next?", this section is here to help you.
+We want you to choose the pages _you_ feel the most comfortable or excited about, but it's most helpful if **all of the introductory pages listed below are translated first**. This allows the most people to learn what Astro is and get started with a project in their native language.
+
+Especially for new languages, **we require the following pages to be translated before we accept translations for other pages.** To make sure we have an active, volunteer community that can keep up with Astro Docs, we require a language crew to demonstrate that they can maintain the pages listed below before translating other pages:
+
+- [Getting Started](https://docs.astro.build/en/getting-started/)
+- [Why Astro?](https://docs.astro.build/en/concepts/why-astro/)
+- [Islands Architecture](https://docs.astro.build/en/concepts/islands/)
+- [Installation](https://docs.astro.build/en/install-and-setup/)
+- [Project Structure](https://docs.astro.build/en/basics/project-structure/)
+- [Develop and Build](https://docs.astro.build/en/develop-and-build/)
+
+If all of these pages are fully up to date and you're asking yourself "What should I translate next?", then read on! This section is here to help you by explaining the rest of the page types in our documentation.
 
 We've separated pages into categories, mostly according to Astro Docs' sidebar organization. Each category is described with an approximate view count, maintenance cost, and page size stats, as well as a description explaining the rationale and other tips.
+
+#### Build a Blog Tutorial
+
+- **View Count:** High
+- **Maintenance:** Medium
+- **Size:** Medium
+
+Although it's a big project, we really value having our "Build a Blog" tutorial translated into as many languages as possible! **We suggest that you work on this next**, as a longer running project, while keeping the initial six pages up to date when docs change.
+
+The tutorial pages include learning-oriented guides on Astro and its features. These pages are especially seen by beginner Astro developers, complex terminology is kept to a minimum, and what is there is well-explained for beginners in small to medium-sized pages.
+
+Even though these pages may be small, they are cummulative, demanding more of translators and reviewers to keep a consistent language across all pages. Translators may need to look at past or future pages to ensure that they are using a consistent vocuabulary and phrasing. Tutorials are also constantly updated based on user feedback, meaning changes are more frequent but generally small and lesson-specific.
+
+**The entire tutorial must be translated before any individual lesson pages can be published.** This is so that a reader does not have to switch languages from one page to the next as they are taking the tutorial, trying to learn Astro. When you are ready to start translating the tutorial, you must **ask for a branch to be created for you** (e.g. `/es-tutorial/`) and must make PRs to your tutorial branch, not to the main branch of Astro docs.
+
+We understand that it may take a long time to completely translate the tutorial, and that's OK! This will also allow you to familiarize yourself with how quickly Astro docs updates, and plan which pages you may want to translate next.
+
+Reminder: You are welcome to update existing tutorial translations, but you must seek guidance before starting to translate a tutorial that does not yet exist.
 
 #### Start Here
 
@@ -198,18 +227,6 @@ An exception is the "Upgrade to vX" guides, which are bigger, contain more termi
 - **Size:** Small
 
 The "Core Concepts" pages explain the reasons to use Astro, its design principles and its architecture. These are among our most viewed pages and are smaller than average, having less than 100 lines each and also rarely changing. On the other hand, these pages introduce considerably more terminology than the "Start Here" pages, making them more complex to translate.
-
-#### Tutorials
-
-- **View Count:** High
-- **Maintenance:** Medium
-- **Size:** Medium
-
-The "Tutorials" pages include learning-oriented guides on Astro and its features. These pages are especially seen by beginner Astro developers, complex terminology is kept to a minimum, and what is there is well-explained for beginners in small to medium-sized pages.
-
-Even though these pages may be small, they are cummulative, demanding more of translators and reviewers to keep a consistent language across all pages. Translators may need to look at past or future pages to ensure that they are using a consistent vocuabulary and phrasing. Tutorials are also constantly updated based on user feedback, meaning changes are more frequent but generally lesson-specific.
-
-Reminder: You are welcome to update existing tutorial translations, but you must seek guidance before starting to translate a tutorial that does not yet exist.
 
 #### Basics
 


### PR DESCRIPTION
This provides more direct guidance about which pages to translate first, especially for new languages.