### PR TITLE
Emphasize third-party guides acceptance criteria

### DIFF
--- a/src/content/docs/guides/new-third-party-guide.mdx
+++ b/src/content/docs/guides/new-third-party-guide.mdx
@@ -55,7 +55,7 @@ The following example shows the process of creating a stub page for Keystatic CM
     ```
 6. Use only the following two `##` (`<h2>`) headings in the body of the file as needed, and [follow the process for adding links](#adding-new-links) to add initial content.
 
-    Two or three links is enough for an initial stub page, and you must not duplicate pages from the same domain. Choose the most relevant entry page for each domain, such as an Astro guide in your documentation, or your most general blog post. If you do not follow the [link requirements](#adding-new-links), your guide will not be accepted:
+    Two or three links is enough for an initial stub page, and you must not duplicate pages from the same domain. Choose the most relevant entry page for each domain, such as an Astro guide in your documentation, or your most general blog post:
 
     ```md wrap title="src/content/docs/en/guides/cms/keystatic.mdx"
     ## Official Resources

--- a/src/content/docs/guides/new-third-party-guide.mdx
+++ b/src/content/docs/guides/new-third-party-guide.mdx
@@ -21,7 +21,7 @@ This allows the third-party service to immediately have a presence in Astro docs
 
 After a stub page exists, you may choose to [write some guide content](#writing-a-guide) which will be reviewed by our docs team. These guides require more significant resources and are subject to our regular docs standards. We will try to work with you to help you create something that fits with the style and conventions of Astro Docs. However, not all guides will necessarily be accepted.
 
-PRs adding full guides to the docs without first creating a stub page or obtaining approval may be refused.
+PRs adding full guides to the docs without first creating a stub page or obtaining approval will be refused.
 
 ## Creating a stub page
 

--- a/src/content/docs/guides/new-third-party-guide.mdx
+++ b/src/content/docs/guides/new-third-party-guide.mdx
@@ -11,13 +11,17 @@ The `src/content/docs/en/guides/` directory in the docs has subdirectories for e
 - `deploy/`
 - `media/`
 
-If you'd like to add a new guide to using Astro with a third-party CMS, backend service, deploy host, etc., the first step is to [create a new, minimal "stub" page](#creating-a-stub-page) in English that links to other existing content (official guides, starter templates and tutorials, as well as community blog posts or videos).
+We welcome guides on using Astro with a third-party CMS, backend service, deploy host, etc. Unfortunately, we have to be selective about what we accept. Adding a new third-party guide means allocating Astro resources to review and maintain it.
+
+If your service is new or not yet widely adopted, we recommend that you write and maintain a guide in your own documentation. You are welcome to suggest adding a link to your guide in the Community Resources section of a relevant page. You can also [open a discussion in the docs repo](https://github.com/withastro/docs/discussions) so we can assess whether there is sufficient interest in the service among the Astro community.
+
+If your service is popular and actively maintained, or has been approved by the Astro team, you are welcome to [create a new, minimal "stub" page](#creating-a-stub-page) in English that links to other existing content (official guides, starter templates and tutorials, as well as community blog posts or videos).
 
 This allows the third-party service to immediately have a presence in Astro docs with minimal reviewing, testing, and editing required from our docs team. It helps others learn about the service, and provides helpful resources for those looking to integrate the service with Astro.
 
 After a stub page exists, you may choose to [write some guide content](#writing-a-guide) which will be reviewed by our docs team. These guides require more significant resources and are subject to our regular docs standards. We will try to work with you to help you create something that fits with the style and conventions of Astro Docs. However, not all guides will necessarily be accepted.
 
-PRs adding full guides to the docs without first creating a stub page may be refused.
+PRs adding full guides to the docs without first creating a stub page or obtaining approval may be refused.
 
 ## Creating a stub page
 

--- a/src/content/docs/guides/new-third-party-guide.mdx
+++ b/src/content/docs/guides/new-third-party-guide.mdx
@@ -13,7 +13,7 @@ The `src/content/docs/en/guides/` directory in the docs has subdirectories for e
 
 We welcome guides on using Astro with a third-party CMS, backend service, deploy host, etc. Unfortunately, we have to be selective about what we accept. Adding a new third-party guide means allocating Astro resources to review and maintain it.
 
-If your service is new or not yet widely adopted, we recommend that you write and maintain a guide in your own documentation. You are welcome to suggest adding a link to your guide in the Community Resources section of a relevant page. You can also [open a discussion in the docs repo](https://github.com/withastro/docs/discussions) so we can assess whether there is sufficient interest in the service among the Astro community.
+If your service is new or not yet widely adopted, we recommend that you write and maintain a guide in your own documentation. You can suggest adding a link to your guide in the "Community Resources" section of a relevant page. You can also [open a discussion in the docs repo](https://github.com/withastro/docs/discussions) so we can assess whether there is sufficient interest in the service among the Astro community.
 
 If your service is popular and actively maintained, or has been approved by the Astro team, you are welcome to [create a new, minimal "stub" page](#creating-a-stub-page) in English that links to other existing content (official guides, starter templates and tutorials, as well as community blog posts or videos).
 

--- a/src/content/docs/guides/new-third-party-guide.mdx
+++ b/src/content/docs/guides/new-third-party-guide.mdx
@@ -15,7 +15,7 @@ We welcome guides on using Astro with a third-party CMS, backend service, deploy
 
 If your service is new or not yet widely adopted, we recommend that you write and maintain a guide in your own documentation. You can suggest adding a link to your guide in the "Community Resources" section of a relevant page. You can also [open a discussion in the docs repo](https://github.com/withastro/docs/discussions) so we can assess whether there is sufficient interest in the service among the Astro community.
 
-If your service is popular and actively maintained, or has been approved by the Astro team, you are welcome to [create a new, minimal "stub" page](#creating-a-stub-page) in English that links to other existing content (official guides, starter templates and tutorials, as well as community blog posts or videos).
+If your service is popular and actively maintained, or has been approved by the Astro team, you are welcome to [create a new, minimal "stub" page](#creating-a-stub-page) in English only that links to other existing content (official guides, starter templates and tutorials, as well as community blog posts or videos).
 
 This allows the third-party service to immediately have a presence in Astro docs with minimal reviewing, testing, and editing required from our docs team. It helps others learn about the service, and provides helpful resources for those looking to integrate the service with Astro.
 
@@ -53,7 +53,10 @@ The following example shows the process of creating a stub page for Keystatic CM
     ```md wrap title="src/content/docs/en/guides/cms/keystatic.mdx"
     [Keystatic](https://keystatic.com/) is an open source, headless content-management system that allows you to structure your content and sync it with GitHub.
     ```
-6. Use only the following `##` (`<h2>`) headings in the body of the file as needed, and [follow the process for adding links](#adding-new-links) to add initial content. Two or three links is enough for an initial stub page:
+6. Use only the following two `##` (`<h2>`) headings in the body of the file as needed, and [follow the process for adding links](#adding-new-links) to add initial content.
+
+    Two or three links is enough for an initial stub page, and you must not duplicate pages from the same domain. Choose the most relevant entry page for each domain, such as an Astro guide in your documentation, or your most general blog post. If you do not follow the [link requirements](#adding-new-links), your guide will not be accepted:
+
     ```md wrap title="src/content/docs/en/guides/cms/keystatic.mdx"
     ## Official Resources
 


### PR DESCRIPTION
### Context

There are a few motivations for this:
- I don't think AI knows how to read so most of the new guides do not follow "the first step is to [create a new, minimal “stub” page](https://contribute.docs.astro.build/guides/new-third-party-guide/#creating-a-stub-page)" (actually, I think there's only one recent guide that has done that... but they don't have any public docs, so...).
- We recently received a request to remove a CMS guide submitted six months ago, because the CMS is no longer maintained... I think this will be pretty common with vibe-coding.
- We have a new guide for a package published two weeks ago... This might be helpful for Astro users, but it seems a bit premature for a guide in Astro Docs (and so for allocating time to review it!), especially since they have docs for other frameworks on their website but not for Astro.

We already mention "PRs adding full guides to the docs without first creating a stub page may be refused.", and this is probably enough to reject the last case. But I think emphasizing the fact that each guide increases maintenance costs could help. (Well, I’m not sure if that’s a problem for AI, but... at least we have "official" guidelines to refer to.)

### Changes

I tried to write something similar to the recommendations in the [i18n guide](https://contribute.docs.astro.build/guides/i18n), but obviously this can't be a copy/paste. I chose a parallel structure with two paragraphs starting with "if". But perhaps talking about "popular"/"actively maintained" is clumsy.

### Other leads

Even though I don't like this, maybe at some point we'll need an `AGENTS.md` file in the Docs repo to enforce AI to read our contributing guide... I mean, we can't reject a docs PR for a feature approved in the core repo. And more and more PRs are written by AI. In this specific context, maybe this could help with "create a stub first". 🤷🏽 

I also thought about skills, but... it seems a bit absurd to repeat what we already have in a condensed form, just to satisfy AI. Plus, it makes maintenance more cumbersome, since you have to check two different places whenever a change is made. 😓 